### PR TITLE
Add helm charts for AYON and Zulip with Keycloak SSO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+helm.zip

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,5 @@
+extends: default
+rules:
+  braces:
+    level: warning
+  document-start: disable

--- a/README.md
+++ b/README.md
@@ -1,0 +1,88 @@
+# AYON and Zulip Helm Charts
+
+This repository contains example Helm charts for deploying [AYON](https://github.com/BalajiDegala/ayon-docker), [Zulip](https://zulip.com), and [Keycloak](https://www.keycloak.org) with ingress and MetalLB for bare-metal clusters.
+
+The charts are located in the `helm/` directory:
+
+- `helm/keycloak` – Keycloak instance providing SSO
+- `helm/ayon` – AYON server configured to use Keycloak
+- `helm/zulip` – Zulip chat server configured to use Keycloak
+
+These charts are intentionally simple and meant as a starting point for a small team (≈250 users). Further tuning might be required for production.
+
+## Prerequisites
+
+1. A Kubernetes cluster (v1.25+) with [MetalLB](https://metallb.universe.tf/) installed and configured to provide external LoadBalancer IPs.
+2. An Ingress controller (e.g. nginx). The charts assume the ingress class name `nginx`.
+3. `helm` installed locally to deploy the charts.
+
+## Quick Start
+
+1. **Install Keycloak**
+
+   ```bash
+   helm install keycloak ./helm/keycloak
+   ```
+
+   After Keycloak is running, create a realm and OAuth clients named `ayon` and `zulip`. Note the client IDs and secrets and update `helm/ayon/values.yaml` and `helm/zulip/values.yaml` accordingly.
+
+2. **Install AYON**
+
+   Build and push the AYON Docker image from [BalajiDegala/ayon-docker](https://github.com/BalajiDegala/ayon-docker) to your registry and set `image.repository` in `helm/ayon/values.yaml`.
+
+   ```bash
+   helm install ayon ./helm/ayon
+   ```
+
+3. **Install Zulip**
+
+   ```bash
+   helm install zulip ./helm/zulip
+   ```
+
+## MetalLB Configuration
+
+MetalLB should provide LoadBalancer addresses for each service. Example:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.14.5/manifests/namespace.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.14.5/manifests/metallb.yaml
+# Configure address pool
+kubectl apply -f metallb-config.yaml
+```
+
+`metallb-config.yaml` might look like:
+
+```yaml
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: default-pool
+  namespace: metallb-system
+spec:
+  addresses:
+    - 192.168.1.240-192.168.1.250
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: l2
+  namespace: metallb-system
+```
+
+## Testing SSO
+
+1. Access Keycloak (e.g. `http://keycloak.local`) and log in with the admin credentials defined in `helm/keycloak/values.yaml`.
+2. Create a realm and clients named `ayon` and `zulip` with `http://ayon.local` and `http://zulip.local` as valid redirect URIs.
+3. Update the corresponding client secrets in the AYON and Zulip chart values.
+4. Deploy the charts and visit the ingress URLs. Login buttons for Keycloak should appear and allow authentication via Keycloak.
+
+## Packaging
+
+A helper script `package.sh` is provided to create `helm.zip` containing all charts:
+
+```bash
+./package.sh
+```
+
+The resulting `helm.zip` can be distributed for installation.

--- a/helm/ayon/Chart.yaml
+++ b/helm/ayon/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: ayon
+version: 0.1.0
+appVersion: "latest"
+description: Deploy AYON server with Keycloak SSO

--- a/helm/ayon/templates/deployment.yaml
+++ b/helm/ayon/templates/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ayon
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ayon
+  template:
+    metadata:
+      labels:
+        app: ayon
+    spec:
+      containers:
+        - name: ayon
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: KEYCLOAK_URL
+              value: {{ .Values.keycloak.url | quote }}
+            - name: KEYCLOAK_REALM
+              value: {{ .Values.keycloak.realm | quote }}
+            - name: KEYCLOAK_CLIENT_ID
+              value: {{ .Values.keycloak.clientId | quote }}
+            - name: KEYCLOAK_CLIENT_SECRET
+              value: {{ .Values.keycloak.clientSecret | quote }}
+          ports:
+            - containerPort: 5000

--- a/helm/ayon/templates/ingress.yaml
+++ b/helm/ayon/templates/ingress.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.ingress.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ayon
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress.className | quote }}
+spec:
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ayon
+                port:
+                  number: {{ .Values.service.port }}
+{{- end }}
+

--- a/helm/ayon/templates/service.yaml
+++ b/helm/ayon/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ayon
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 5000
+      protocol: TCP
+      name: http
+  selector:
+    app: ayon

--- a/helm/ayon/values.yaml
+++ b/helm/ayon/values.yaml
@@ -1,0 +1,16 @@
+image:
+  repository: ayon-self-docker
+  tag: "latest"
+  pullPolicy: IfNotPresent
+service:
+  type: ClusterIP
+  port: 5000
+keycloak:
+  url: http://keycloak:8080
+  realm: ayon
+  clientId: ayon
+  clientSecret: ayonsecret
+ingress:
+  enabled: true
+  className: nginx
+  host: ayon.local

--- a/helm/keycloak/Chart.yaml
+++ b/helm/keycloak/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: keycloak
+version: 0.1.0
+appVersion: "latest"
+description: Deploy Keycloak for SSO

--- a/helm/keycloak/templates/deployment.yaml
+++ b/helm/keycloak/templates/deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keycloak
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keycloak
+  template:
+    metadata:
+      labels:
+        app: keycloak
+    spec:
+      containers:
+        - name: keycloak
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: KEYCLOAK_ADMIN
+              value: {{ .Values.adminUser | quote }}
+            - name: KEYCLOAK_ADMIN_PASSWORD
+              value: {{ .Values.adminPassword | quote }}
+          args: ["start"]
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: data
+              mountPath: /opt/keycloak/data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: keycloak-data

--- a/helm/keycloak/templates/ingress.yaml
+++ b/helm/keycloak/templates/ingress.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.ingress.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: keycloak
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress.className | quote }}
+spec:
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: keycloak
+                port:
+                  number: {{ .Values.service.port }}
+{{- end }}
+

--- a/helm/keycloak/templates/pvc.yaml
+++ b/helm/keycloak/templates/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: keycloak-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  storageClassName: standard

--- a/helm/keycloak/templates/service.yaml
+++ b/helm/keycloak/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: keycloak

--- a/helm/keycloak/values.yaml
+++ b/helm/keycloak/values.yaml
@@ -1,0 +1,16 @@
+image:
+  repository: quay.io/keycloak/keycloak
+  tag: "24.0"
+  pullPolicy: IfNotPresent
+adminUser: admin
+adminPassword: admin
+service:
+  type: ClusterIP
+  port: 8080
+persistence:
+  enabled: true
+  size: 1Gi
+ingress:
+  enabled: true
+  className: nginx
+  host: keycloak.local

--- a/helm/zulip/Chart.yaml
+++ b/helm/zulip/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: zulip
+version: 0.1.0
+appVersion: "latest"
+description: Deploy Zulip chat with Keycloak SSO

--- a/helm/zulip/templates/deployment.yaml
+++ b/helm/zulip/templates/deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zulip
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: zulip
+  template:
+    metadata:
+      labels:
+        app: zulip
+    spec:
+      containers:
+        - name: zulip
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: SOCIAL_AUTH_OIDC_ENABLED
+              value: "true"
+            - name: SOCIAL_AUTH_OIDC_PROVIDER_NAME
+              value: keycloak
+            - name: SOCIAL_AUTH_OIDC_PROVIDER_URL
+              value: {{ .Values.keycloak.url | quote }}
+            - name: SOCIAL_AUTH_OIDC_KEY
+              value: {{ .Values.keycloak.clientId | quote }}
+            - name: SOCIAL_AUTH_OIDC_SECRET
+              value: {{ .Values.keycloak.clientSecret | quote }}
+            - name: SETTING_EXTERNAL_HOST
+              value: {{ .Values.ingress.host | quote }}
+          ports:
+            - containerPort: 80

--- a/helm/zulip/templates/ingress.yaml
+++ b/helm/zulip/templates/ingress.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.ingress.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: zulip
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress.className | quote }}
+spec:
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: zulip
+                port:
+                  number: {{ .Values.service.port }}
+{{- end }}
+

--- a/helm/zulip/templates/service.yaml
+++ b/helm/zulip/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: zulip
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 80
+      protocol: TCP
+      name: http
+  selector:
+    app: zulip

--- a/helm/zulip/values.yaml
+++ b/helm/zulip/values.yaml
@@ -1,0 +1,16 @@
+image:
+  repository: zulip/docker-zulip
+  tag: "8.0-0"
+  pullPolicy: IfNotPresent
+service:
+  type: ClusterIP
+  port: 80
+keycloak:
+  url: http://keycloak:8080
+  realm: zulip
+  clientId: zulip
+  clientSecret: zulipsecret
+ingress:
+  enabled: true
+  className: nginx
+  host: zulip.local

--- a/package.sh
+++ b/package.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+zip -r helm.zip helm >/dev/null


### PR DESCRIPTION
## Summary
- Add helm charts for Keycloak, AYON and Zulip
- Provide README instructions and MetalLB example
- Include helper script to package charts
- Add yamllint configuration

## Testing
- `yamllint -c .yamllint helm` *(fails: syntax error due to Jinja templating)*
- `./package.sh`

------
https://chatgpt.com/codex/tasks/task_e_68447135c144832da12fb33ca81c9d7a